### PR TITLE
Also define base-16 value for "unused" color in default_clone template.

### DIFF
--- a/templates/default_clone.colortemplate
+++ b/templates/default_clone.colortemplate
@@ -294,7 +294,7 @@ Background: any
 # Black&White variant {{{
 Variant: 2
 
-Color: unused #000000 0
+Color: unused #000000 0 0
 
 # Default highlight groups {{{
 # Group              Unused   Unused   term


### PR DESCRIPTION
Also define base-16 value for "unused" color in `default_clone.template`.

Tested: Able to generate this template using :Colortemplate now.

(Commit ebdfb8e668802ed35c820bca595f48e2bf435b5e took care of the same in `_bw.template`.)