### PR TITLE
Test vim-colortemplate using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: minimal
+dist: xenial
+services:
+  - docker
+
+before_install:
+  - docker build -t vim-colortemplate .
+
+before_script:
+  - docker run -t vim-colortemplate vim --version
+
+script:
+  - docker run -t vim-colortemplate sh -c 'set -x; cd /vim-colortemplate; mkdir -p /tmp/scratch; vim -E -u NONE -N --cmd "set rtp+=\$PWD modeline hidden | filetype plugin on" templates/default_clone.colortemplate -c "Colortemplate /tmp/scratch" -c "qa!"; ls -l /tmp/scratch/colors/; test -s /tmp/scratch/colors/default_clone.vim'
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+# For testing vim-colortemplate:
+FROM ubuntu:18.04
+RUN apt-get update && apt-get -y install vim
+COPY . /vim-colortemplate


### PR DESCRIPTION
Test vim-colortemplate using Travis-CI.

Use a Docker image based on Ubuntu 19.04, which includes vim 8.1.320.

Run a vim command-line that loads `templates/default_clone.colortemplate` and tries to run `:Colortemplate` on it. Check that the resulting `colors/default_clone.vim` was generated and that it is not an empty file.

Such a test can be configured to run on both the master branch and on open PRs, it should make sure that the default template is kept working as the code evolves.

See here for what a Travis-CI run looks like (you should set it up on your repo as well, after merging this PR):
https://travis-ci.org/filbranden/vim-colortemplate/builds/544461932

**NOTE:** I can evolve this into doing more. It should probably generate the 4 shipped colortemplates rather than just the default one. It would also be useful to run the tests in `test/` through a CI such as this one.

It would also be useful to test multiple versions of vim. For instance, using a similar test as this one, I noticed that vim 8.0.1453 actually doesn't work. I'll send a separate fix for that... Do you intend to support older versions of vim such as 7.4.x? That can also be helped by testing from a CI such as this one.

Cheers!
Filipe
