### PR TITLE
Add an ftdetect hook for the filetype

### DIFF
--- a/ftdetect/colortemplate.vim
+++ b/ftdetect/colortemplate.vim
@@ -1,0 +1,1 @@
+autocmd BufRead,BufNewFile *.colortemplate setfiletype colortemplate


### PR DESCRIPTION
Add an `ftdetect` hook for the filetype, in order to make it work for files with the file extension, obviating the need to set the filetype from the modeline.

(See [Vim docs on new filetype](https://vimhelp.org/filetype.txt.html#new-filetype) for more details.)

Tested: Opened a file without the `vim: ft=colortemplate` modeline and confirmed it got the filetype set correctly, `:Colortemplate` command working on the buffer.

Also confirmed that it works with `set nomodeline` in vimrc.