### PR TITLE
Highlight Todos as what they are

### DIFF
--- a/syntax/colortemplate.vim
+++ b/syntax/colortemplate.vim
@@ -172,6 +172,6 @@ hi def link colortemplateKey          Special
 hi def link colortemplateKeyword      Keyword
 hi def link colortemplateSpecial      Boolean
 hi def link colortemplateTermCode     String
-hi def link colortemplateTodo         PreProc
+hi def link colortemplateTodo         Todo
 
 let b:current_syntax = "colortemplate"


### PR DESCRIPTION
Hi,

This pull request changes the highlighting of `TODO`s in Colortemplate from being linked to `PreProc` to the `Todo` highlight group. Is there any reason why it was linked to `PreProc` before?

Thanks.