### PR TITLE
fix: use silent! for #call

### DIFF
--- a/autoload/colortemplate.vim
+++ b/autoload/colortemplate.vim
@@ -2071,6 +2071,9 @@ fun! s:parse_command(cmd)
     throw a:cmd.' without if'
   endif
   let l:text = matchstr(s:getl(), '^\s*#\zs.\{-}\s*$')
+  if l:text =~ '^call!'
+    let l:text = 'silent! ' . l:text
+  endif
   for l:v in s:active_variants()
     call s:add_verbatim_item(l:v, s:active_section(),
           \ { 'line': l:text, 'linenr': s:linenr(), 'file': s:currfile() })

--- a/doc/colortemplate.txt
+++ b/doc/colortemplate.txt
@@ -514,7 +514,7 @@ insert the current Vim version).
 Verbatim blocks are most often used for conditionals or to set and get
 variables or to invoke functions. Therefore, Colortemplate provides convenient
 shortcuts for such cases. When `#if`, `#else`, `#elseif`, `#endif`, `#let`,
-`#unlet` and `#call` appear at the start of a line, they act as one-line
+`#unlet` and `#call[!]` appear at the start of a line, they act as one-line
 verbatim blocks. Such directives are replaced by the corresponding Vim
 commands and what follows is copied verbatim (but interpolated). So, for
 instance, this template:
@@ -530,6 +530,8 @@ is translated into
 	endif
 <
 assuming that `MyColor` is a color with GUI value `#abcdef`.
+
+Note: `#call!` will silently ignore errors.
 
 ==============================================================================
 Documentation blocks				*colortemplate-doc-blocks*


### PR DESCRIPTION
Calls to unsourced functions can cause errors when a colorscheme is
loaded in a vim instance started with --noplugin.

Alternatively, the `silent!` part could be made explicit by writing `#call!` instead of `#call`, but I don't think it's necessary.