### PR TITLE
fix: set t_Co=0 doesn't work for variant: 0

### DIFF
--- a/autoload/colortemplate.vim
+++ b/autoload/colortemplate.vim
@@ -2365,7 +2365,7 @@ fun! s:print_header(bufnr)
     endfor
   endif
   call s:put(a:bufnr,   ''                                                                      )
-  call s:put(a:bufnr,   "let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1")
+  call s:put(a:bufnr,   "let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1")
   if s:uses_italics()
     let l:itcheck =  "let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')"
     if s:supports_neovim()

--- a/autoload/colortemplate.vim
+++ b/autoload/colortemplate.vim
@@ -2365,7 +2365,7 @@ fun! s:print_header(bufnr)
     endfor
   endif
   call s:put(a:bufnr,   ''                                                                      )
-  call s:put(a:bufnr,   "let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1")
+  call s:put(a:bufnr,   "let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1")
   if s:uses_italics()
     let l:itcheck =  "let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')"
     if s:supports_neovim()

--- a/test/expected/test1.vim
+++ b/test/expected/test1.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test1'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test1.vim
+++ b/test/expected/test1.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test1'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test22.vim
+++ b/test/expected/test22.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test22'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test22.vim
+++ b/test/expected/test22.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test22'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test24.vim
+++ b/test/expected/test24.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test24'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 hi! link ColorColumn Normal

--- a/test/expected/test24.vim
+++ b/test/expected/test24.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test24'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 hi! link ColorColumn Normal

--- a/test/expected/test27.vim
+++ b/test/expected/test27.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test27'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#000000 guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test27.vim
+++ b/test/expected/test27.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test27'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#000000 guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test28.vim
+++ b/test/expected/test28.vim
@@ -6,7 +6,7 @@
 hi clear
 let g:colors_name = 'test28'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if &background ==# 'dark'
   hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test28.vim
+++ b/test/expected/test28.vim
@@ -6,7 +6,7 @@
 hi clear
 let g:colors_name = 'test28'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if &background ==# 'dark'
   hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test29.vim
+++ b/test/expected/test29.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test29'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test29.vim
+++ b/test/expected/test29.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test29'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test30.vim
+++ b/test/expected/test30.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test30'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test30.vim
+++ b/test/expected/test30.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test30'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test33.vim
+++ b/test/expected/test33.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test33'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#000000 guibg=#ffffff gui=NONE cterm=NONE
 

--- a/test/expected/test33.vim
+++ b/test/expected/test33.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test33'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#000000 guibg=#ffffff gui=NONE cterm=NONE
 

--- a/test/expected/test34.vim
+++ b/test/expected/test34.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test34'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test34.vim
+++ b/test/expected/test34.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test34'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test37.vim
+++ b/test/expected/test37.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test37'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test37.vim
+++ b/test/expected/test37.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test37'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test38a.vim
+++ b/test/expected/test38a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test38a'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 hi PreProc guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test38a.vim
+++ b/test/expected/test38a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test38a'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 hi PreProc guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test41.vim
+++ b/test/expected/test41.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test41'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test41.vim
+++ b/test/expected/test41.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test41'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test42.vim
+++ b/test/expected/test42.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test42'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg='ghost white' guibg=BlanchedAlmond gui=NONE cterm=NONE
 

--- a/test/expected/test42.vim
+++ b/test/expected/test42.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test42'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg='ghost white' guibg=BlanchedAlmond gui=NONE cterm=NONE
 

--- a/test/expected/test43.vim
+++ b/test/expected/test43.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test43'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test43.vim
+++ b/test/expected/test43.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test43'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test44a.vim
+++ b/test/expected/test44a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test44a'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test44a.vim
+++ b/test/expected/test44a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test44a'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test46a.vim
+++ b/test/expected/test46a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test46a'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 hi ColorColumn guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test46a.vim
+++ b/test/expected/test46a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test46a'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 hi ColorColumn guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test5.vim
+++ b/test/expected/test5.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test5'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi ColorColumn guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test5.vim
+++ b/test/expected/test5.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test5'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi ColorColumn guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test50a.vim
+++ b/test/expected/test50a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test50a'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test50a.vim
+++ b/test/expected/test50a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test50a'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test50b.vim
+++ b/test/expected/test50b.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test50b'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 let g:terminal_ansi_colors = ['#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000']

--- a/test/expected/test50b.vim
+++ b/test/expected/test50b.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test50b'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 let g:terminal_ansi_colors = ['#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000','#000000']

--- a/test/expected/test53.vim
+++ b/test/expected/test53.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test53'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test53.vim
+++ b/test/expected/test53.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test53'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test58.vim
+++ b/test/expected/test58.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test58'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if 1 " some condition
   hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test58.vim
+++ b/test/expected/test58.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test58'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if 1 " some condition
   hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test59.vim
+++ b/test/expected/test59.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test59'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')
 
 if s:t_Co >= 256

--- a/test/expected/test59.vim
+++ b/test/expected/test59.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test59'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')
 
 if s:t_Co >= 256

--- a/test/expected/test60.vim
+++ b/test/expected/test60.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test60'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   let black = '#000000'

--- a/test/expected/test60.vim
+++ b/test/expected/test60.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test60'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   let black = '#000000'

--- a/test/expected/test61.vim
+++ b/test/expected/test61.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test61'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 let x256 = '236'
 let x16  = 'Black'

--- a/test/expected/test61.vim
+++ b/test/expected/test61.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test61'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 let x256 = '236'
 let x16  = 'Black'

--- a/test/expected/test63.vim
+++ b/test/expected/test63.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test63'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 call foo()
 

--- a/test/expected/test63.vim
+++ b/test/expected/test63.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test63'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 call foo()
 

--- a/test/expected/test64.vim
+++ b/test/expected/test64.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test64'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if 1
 elseif ok

--- a/test/expected/test64.vim
+++ b/test/expected/test64.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test64'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if 1
 elseif ok

--- a/test/expected/test65.vim
+++ b/test/expected/test65.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test65'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=NONE guibg=NONE gui=NONE ctermfg=NONE ctermbg=NONE cterm=NONE
 hi LineNr guifg=NONE guibg=NONE gui=NONE ctermfg=NONE ctermbg=NONE cterm=NONE

--- a/test/expected/test65.vim
+++ b/test/expected/test65.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test65'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=NONE guibg=NONE gui=NONE ctermfg=NONE ctermbg=NONE cterm=NONE
 hi LineNr guifg=NONE guibg=NONE gui=NONE ctermfg=NONE ctermbg=NONE cterm=NONE

--- a/test/expected/test68a.vim
+++ b/test/expected/test68a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test68a'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=16 ctermbg=16 cterm=NONE

--- a/test/expected/test68a.vim
+++ b/test/expected/test68a.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test68a'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=16 ctermbg=16 cterm=NONE

--- a/test/expected/test7.vim
+++ b/test/expected/test7.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test7'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=reverse cterm=reverse
 

--- a/test/expected/test7.vim
+++ b/test/expected/test7.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test7'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=reverse cterm=reverse
 

--- a/test/expected/test70.vim
+++ b/test/expected/test70.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test70'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guibg=#000000
 hi CursorLine guifg=#ffffff

--- a/test/expected/test70.vim
+++ b/test/expected/test70.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test70'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guibg=#000000
 hi CursorLine guifg=#ffffff

--- a/test/expected/test72.vim
+++ b/test/expected/test72.vim
@@ -6,7 +6,7 @@
 hi clear
 let g:colors_name = 'test72'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff']

--- a/test/expected/test72.vim
+++ b/test/expected/test72.vim
@@ -6,7 +6,7 @@
 hi clear
 let g:colors_name = 'test72'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff', '#000000', '#ffffff']

--- a/test/expected/test73.vim
+++ b/test/expected/test73.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test73'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if 1
 	hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test73.vim
+++ b/test/expected/test73.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test73'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if 1
 	hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test74.vim
+++ b/test/expected/test74.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test74'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 16
   hi Normal ctermfg=15 ctermbg=NONE cterm=NONE

--- a/test/expected/test74.vim
+++ b/test/expected/test74.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test74'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 16
   hi Normal ctermfg=15 ctermbg=NONE cterm=NONE

--- a/test/expected/test76.vim
+++ b/test/expected/test76.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test76'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi! link PopupSelected PmenuSel
 hi! link QuickFixLine Search

--- a/test/expected/test76.vim
+++ b/test/expected/test76.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test76'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi! link PopupSelected PmenuSel
 hi! link QuickFixLine Search

--- a/test/expected/test77.vim
+++ b/test/expected/test77.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test77'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=7 ctermbg=NONE cterm=NONE

--- a/test/expected/test77.vim
+++ b/test/expected/test77.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test77'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=7 ctermbg=NONE cterm=NONE

--- a/test/expected/test78.vim
+++ b/test/expected/test78.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test78'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=16 ctermbg=NONE cterm=NONE

--- a/test/expected/test78.vim
+++ b/test/expected/test78.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test78'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=16 ctermbg=NONE cterm=NONE

--- a/test/expected/test79.vim
+++ b/test/expected/test79.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test79'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=0 ctermbg=0 cterm=NONE

--- a/test/expected/test79.vim
+++ b/test/expected/test79.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test79'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=0 ctermbg=0 cterm=NONE

--- a/test/expected/test80.vim
+++ b/test/expected/test80.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test80'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 silent! call foo()
 

--- a/test/expected/test80.vim
+++ b/test/expected/test80.vim
@@ -8,7 +8,7 @@ set background=light
 hi clear
 let g:colors_name = 'test80'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 silent! call foo()
 

--- a/test/expected/test81.vim
+++ b/test/expected/test81.vim
@@ -12,7 +12,7 @@ endif
 
 let g:colors_name = 'test81'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=16 ctermbg=16 cterm=NONE

--- a/test/expected/test81.vim
+++ b/test/expected/test81.vim
@@ -12,7 +12,7 @@ endif
 
 let g:colors_name = 'test81'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if s:t_Co >= 256
   hi Normal ctermfg=16 ctermbg=16 cterm=NONE

--- a/test/expected/test82.vim
+++ b/test/expected/test82.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test82'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#a34c9e guibg=#ffffff gui=NONE cterm=NONE
 

--- a/test/expected/test82.vim
+++ b/test/expected/test82.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test82'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#a34c9e guibg=#ffffff gui=NONE cterm=NONE
 

--- a/test/expected/test83.vim
+++ b/test/expected/test83.vim
@@ -20,7 +20,7 @@ let s:maintainer      = 'w'
 let s:license         = 'Vim License (see `:help license`)'
 let s:description     = 'Color scheme with custom reset block'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 " Verbatim block 1
 hi Normal guifg=#a34c9e guibg=#ffffff gui=NONE cterm=NONE

--- a/test/expected/test83.vim
+++ b/test/expected/test83.vim
@@ -20,7 +20,7 @@ let s:maintainer      = 'w'
 let s:license         = 'Vim License (see `:help license`)'
 let s:description     = 'Color scheme with custom reset block'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 " Verbatim block 1
 hi Normal guifg=#a34c9e guibg=#ffffff gui=NONE cterm=NONE

--- a/test/expected/test84.vim
+++ b/test/expected/test84.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test84'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test84.vim
+++ b/test/expected/test84.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test84'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test88.vim
+++ b/test/expected/test88.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test88'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test88.vim
+++ b/test/expected/test88.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test88'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE

--- a/test/expected/test89.vim
+++ b/test/expected/test89.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test89'
 
-let s:t_Co = exists('&t_Co') && !empty(&t_Co) && &t_Co >= 0 ? &t_Co : -1
+let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 

--- a/test/expected/test89.vim
+++ b/test/expected/test89.vim
@@ -8,7 +8,7 @@ set background=dark
 hi clear
 let g:colors_name = 'test89'
 
-let s:t_Co = exists('&t_Co') && &t_Co >= 0 ? (&t_Co ?? 0) : -1
+let s:t_Co = exists('&t_Co') ? (&t_Co ?? 0) : -1
 
 hi Normal guifg=#ffffff guibg=#000000 gui=NONE cterm=NONE
 


### PR DESCRIPTION
If you have set variant: 0 in a template and then try test it by
manually setting `:set t_Co=0` you're out of luck.

For some reason vim sets t_Co value to null/empty if you do set t_Co=0
*for the first time*.

Should fix: https://github.com/vim/colorschemes/issues/202