### PR TITLE
Fix setting of `s:t_Co` for Neovim

### DIFF
--- a/autoload/colortemplate.vim
+++ b/autoload/colortemplate.vim
@@ -2368,8 +2368,12 @@ fun! s:print_header(bufnr)
       call s:put(a:bufnr, s:interpolate('global', 'preamble', l:item.line, l:item.linenr, l:item.file))
     endfor
   endif
-  call s:put(a:bufnr,   ''                                                                      )
-  call s:put(a:bufnr,   "let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ?? 0) : -1")
+  call s:put(a:bufnr,   ''                                                                         )
+  if s:supports_neovim()
+    call s:put(a:bufnr,   "let s:t_Co = exists('&t_Co') && !has('gui_running') ? +&t_Co : -1"      )
+  else
+    call s:put(a:bufnr,   "let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ?? 0) : -1")
+  endif
   if s:uses_italics()
     let l:itcheck =  "let s:italics = (&t_ZH != '' && &t_ZH != '[7m') || has('gui_running')"
     if s:supports_neovim()


### PR DESCRIPTION
Neovim doesn't support the falsy operator (as of version 0.7.2), so we use the `+<expr>` trick to convert `&t_Co` into a number, since that's how it is used in generated color schemes.

Fixes #63.