### PR TITLE
fix for #74

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /colors
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /colors
-tags

--- a/ftplugin/colortemplate.vim
+++ b/ftplugin/colortemplate.vim
@@ -11,10 +11,8 @@ let b:did_ftplugin = 1
 let s:undo_ftplugin = "setlocal commentstring< omnifunc< | unlet! b:colortemplate_outdir"
 let b:undo_ftplugin = (exists('b:undo_ftplugin') ? b:undo_ftplugin .. '|' : '') .. s:undo_ftplugin
 
-let b:colortemplate_outdir = empty(expand('%:p:h')) ? getcwd() : expand('%:p:h')
-if b:colortemplate_outdir =~? '\m\%(color\)\=templates\=$'
-  let b:colortemplate_outdir = fnamemodify(b:colortemplate_outdir, ':h')
-endif
+let b:colortemplate_head = expand('%:p:h:S')
+let b:colortemplate_outdir = empty(b:colortemplate_head) ? fnamemodify(getcwd(), ':p:h:S') : b:colortemplate_head
 if get(g:, 'colortemplate_rtp', 1)
   execute 'set runtimepath^=' .. b:colortemplate_outdir
 endif

--- a/ftplugin/colortemplate.vim
+++ b/ftplugin/colortemplate.vim
@@ -11,8 +11,11 @@ let b:did_ftplugin = 1
 let s:undo_ftplugin = "setlocal commentstring< omnifunc< | unlet! b:colortemplate_outdir"
 let b:undo_ftplugin = (exists('b:undo_ftplugin') ? b:undo_ftplugin .. '|' : '') .. s:undo_ftplugin
 
-let b:colortemplate_head = expand('%:p:h:S')
-let b:colortemplate_outdir = empty(b:colortemplate_head) ? fnamemodify(getcwd(), ':p:h:S') : b:colortemplate_head
+let b:colortemplate_head = escape(expand('%:p:h'), ' ')
+let b:colortemplate_outdir = empty(b:colortemplate_head) ? escape(fnamemodify(getcwd(), ':p:h'), ' ') : b:colortemplate_head
+if b:colortemplate_outdir =~? '\m\%(color\)\=templates\=$'
+  let b:colortemplate_outdir = fnamemodify(b:colortemplate_outdir, ':h')
+endif
 if get(g:, 'colortemplate_rtp', 1)
   execute 'set runtimepath^=' .. b:colortemplate_outdir
 endif


### PR DESCRIPTION
Adding the `:h` modifier to the `expand` function resolves an issue with path truncation when the path contains a space character.