### PR TITLE
Support nvim 0.8 @group.name

### DIFF
--- a/autoload/colortemplate.vim
+++ b/autoload/colortemplate.vim
@@ -1355,8 +1355,8 @@ fun! s:token.next() dict
     let self.kind = 'EOL'
     let self.spos = len(s:getl()) - 1 " For correct error location
     let self.pos = len(s:getl()) " Makes next() at eol idempotent
-  elseif l:char =~? '\m\a'
-    let [self.value, self.spos, self.pos] = matchstrpos(s:getl(), '\w\+', self.pos - 1)
+  elseif l:char =~? '\m\a\|@'
+    let [self.value, self.spos, self.pos] = matchstrpos(s:getl(), '@\?\w\+\(\.\w\+\)*', self.pos - 1)
     let self.kind = 'WORD'
   elseif l:char =~# '\m[0-9]'
     let [self.value, self.spos, self.pos] = matchstrpos(s:getl(), '\d\+', self.pos - 1)

--- a/syntax/colortemplate.vim
+++ b/syntax/colortemplate.vim
@@ -12,6 +12,7 @@ syn case    match
 syn match   colortemplateAttrs        "\<\%(te\?r\?m\?\|gu\?i\?\)=\S\+" contains=colortemplateAttr,colortemplateSpecial
 syn match   colortemplateGuisp        "\<\%(guisp\|sp\?\)="
 syn match   colortemplateTermCode     "\<st\%(art\|op\)="
+syn match   colortemplateHiGroup      "@\w\+\%(\.\w\+\)*"
 syn match   colortemplateHiGroup      "\<Conceal\>"
 syn match   colortemplateHiGroup      "\<Include\>"
 syn match   colortemplateHiGroup      "\<Terminal\>"


### PR DESCRIPTION
Nvim 0.8 introduced scoped highlight group of the form "@group.name", and uses it for treesitter and LSP semantic token highlighting.

See: https://github.com/neovim/neovim/blob/fdc8e966a9183c08f2afec0817d03b7417a883b3/runtime/doc/treesitter.txt#L350

Example usage: https://github.com/tomtomjhj/quite.vim/blob/a95ab4a8638056cabfef3117a1b137ef7ed13bde/templates/quite.colortemplate#L57