### PR TITLE
Fix type error in sample code

### DIFF
--- a/doc/colortemplate.txt
+++ b/doc/colortemplate.txt
@@ -1159,8 +1159,8 @@ define the way you like. For example:
 >
 	#const italic = &t_ZH != '' && &t_ZH != '^[[7m'
 	; ...
-	Comment           gray  black
-	  /256+italic 1   omit  omit  s=omit  italic
+	Comment             gray  black
+	  /256+italic true  omit  omit  s=omit  italic
 <
 The special color must appear before the style attributes ~
 


### PR DESCRIPTION
Using the previous sample code causes a type error in Vim.

```
E1072: Cannot compare bool with number
```